### PR TITLE
build: add debuginfo image and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ LABEL io.k8s.description="$DESCRIPTION" \
       name="bucharestgold/centos7-s2i-nodejs"
 
 COPY ./s2i/ $STI_SCRIPTS_PATH
-COPY ./contrib/ /opt/app-root
+COPY ./contrib/etc/install_node.sh /opt/app-root/etc/install_node.sh
 
 RUN /opt/app-root/etc/install_node.sh
 

--- a/Dockerfile.debuginfo
+++ b/Dockerfile.debuginfo
@@ -1,0 +1,23 @@
+FROM centos:centos7
+
+ARG NODE_VERSION
+ARG NPM_VERSION
+ARG DOWNLOAD_URL=https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}
+
+RUN echo ${DOWNLOAD_URL}
+RUN yum install -y ${DOWNLOAD_URL}/rhoar-nodejs-${NODE_VERSION}-1.el7.centos.x86_64.rpm \
+  ${DOWNLOAD_URL}/npm-${NPM_VERSION}-1.${NODE_VERSION}.1.el7.centos.x86_64.rpm \
+  ${DOWNLOAD_URL}/rhoar-nodejs-debuginfo-${NODE_VERSION}-1.el7.centos.x86_64.rpm && \
+  INSTALL_PKGS="bzip2 \
+  gdb \
+  lsof \
+  procps-ng \
+  unzip \
+  wget" && \
+  yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+  rpm -V $INSTALL_PKGS && \
+  yum clean all -y
+
+USER 1001
+
+CMD "/bin/bash"

--- a/Dockerfile.debuginfo
+++ b/Dockerfile.debuginfo
@@ -18,6 +18,9 @@ RUN yum install -y ${DOWNLOAD_URL}/rhoar-nodejs-${NODE_VERSION}-1.el7.centos.x86
   rpm -V $INSTALL_PKGS && \
   yum clean all -y
 
+COPY ./contrib/etc/gdbinit /etc/gdbinit
+RUN echo 'alias gdb="gdb -q"' >> /etc/profile.d/gdb.sh
+
 USER 1001
 
-CMD "/bin/bash"
+CMD ["/bin/bash", "-l"]

--- a/Dockerfile.debuginfo
+++ b/Dockerfile.debuginfo
@@ -4,6 +4,19 @@ ARG NODE_VERSION
 ARG NPM_VERSION
 ARG DOWNLOAD_URL=https://github.com/bucharest-gold/node-rpm/releases/download/v${NODE_VERSION}
 
+ENV SUMMARY="Image for remote gdb debugging of Node.js $NODE_VERSION applications" \
+    DESCRIPTION="This image contains Node.js $NODE_VERSION and gdb allowing \
+it to be used to remote debug Node.js applications."
+
+LABEL io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Node.js $NODE_VERSION" \
+      io.openshift.tags="nodejs,nodejs-$NODE_VERSION" \
+      maintainer="Daniel Bevenius <daniel.bevenius@gmail.com>" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      version="$NODE_VERSION" \
+      name="bucharestgold/centos7-s2i-nodejs-debuginfo"
+
 RUN echo ${DOWNLOAD_URL}
 RUN yum install -y ${DOWNLOAD_URL}/rhoar-nodejs-${NODE_VERSION}-1.el7.centos.x86_64.rpm \
   ${DOWNLOAD_URL}/npm-${NPM_VERSION}-1.${NODE_VERSION}.1.el7.centos.x86_64.rpm \

--- a/contrib/etc/gdbinit
+++ b/contrib/etc/gdbinit
@@ -1,0 +1,2 @@
+set auto-load safe-path /
+set build-id-verbose 0

--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-INSTALL_PKGS="centos-release-scl nss_wrapper rh-git29"
+INSTALL_PKGS="centos-release-scl nss_wrapper rh-git29 gdb-gdbserver"
 
 yum remove -y rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon
 

--- a/doc/gdb-debugging.md
+++ b/doc/gdb-debugging.md
@@ -25,6 +25,11 @@ $ gdbserver 172.17.0.6:7777 --attach 30
 Attached; pid = 30
 Listening on port 7777
 ```
+The ip address used should be that of the pod which can be found by running:
+```console
+$ hostname -i
+172.17.0.6
+```
 The gdbserver is now listening for connections.
 
 #### Start the debuginfo image

--- a/doc/gdb-debugging.md
+++ b/doc/gdb-debugging.md
@@ -1,0 +1,54 @@
+### GDB Debugging
+This document describes the options available for debugging node using the GNU debugger.
+
+We don't provide the debuginfo package, which contains the symbols required for debugging, as this would make our runtime image about 480MB larger. On systems where root access is allowed then the debuinfo package can simply be installed using yum/rpm, but on others like OpenShift getting a pod to run with root access can be somewhat tricky. 
+
+### OpenShift
+When running an application on OpenShift the pod will not have root access. It is possible to configure such access but that means configuring the OpenShift environment. This section provides an alternative to that which allows debugging the application using a remote gdb session. This is done by starting a container in the same cluster with an image with the node runtime and debuginfo, and then connecting to the pod that is the target of the debugging.
+
+#### Start/attach to the running process
+First step is to start the gdbserver on the pod that is the target of the debugging session:
+```
+$ oc rsh nodejs-rest-http-1-nw7hz
+$ gdbserver 172.17.0.6:7777 --attach 23
+Attached; pid = 23
+Listening on port 7777
+```
+In the above case we are creating a new process, but this could also just be the process id of a process running on the pod.
+
+#### Start the debuginfo image
+The next step is to start a container with the debuginfo image in the same cluster.
+
+```console
+$ oc run -i -t nodejs-debuginfo --image=bucharestgold/centos7-s2i-nodejs2-debuginfo:10.x --restart=Never
+```
+Then start gdb specifying the executable which is `node` in our case: 
+```console
+bash-4.2$ gdb node
+Reading symbols from /usr/bin/node...Reading symbols from /usr/lib/debug/usr/bin/node.debug...done.
+done.
+(gdb)
+```
+Then, start a remote debugging session to the target pod:
+```console
+(gdb) target remote 172.17.0.6:7777
+```
+Next breakpoints can be set and debugging can start:
+```console
+(gdb) break main
+Breakpoint 1 at 0x95df50: file ../src/node_main.cc, line 94.
+(gdb) continue
+Continuing.
+
+Breakpoint 1, main (argc=3, argv=0x7fffffffe418) at ../src/node_main.cc:94
+94      int main(int argc, char* argv[]) {
+```
+
+
+### Install debuginfo
+This option can be used in cases where root access is available.
+
+The following shows an example of installing debuginfo for `v10.11.0`:
+```console
+yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v10.11.0/rhoar-nodejs-debuginfo-10.11.0-1.el7.centos.x86_64.rpm
+```

--- a/doc/gdb-debugging.md
+++ b/doc/gdb-debugging.md
@@ -6,23 +6,35 @@ We don't provide the debuginfo package, which contains the symbols required for 
 ### OpenShift
 When running an application on OpenShift the pod will not have root access. It is possible to configure such access but that means configuring the OpenShift environment. This section provides an alternative to that which allows debugging the application using a remote gdb session. This is done by starting a container in the same cluster with an image with the node runtime and debuginfo, and then connecting to the pod that is the target of the debugging.
 
+The example used in this document is [nodejs-rest-http](https://github.com/bucharest-gold/nodejs-rest-http).
+
 #### Start/attach to the running process
 First step is to start the gdbserver on the pod that is the target of the debugging session:
 ```
 $ oc rsh nodejs-rest-http-1-nw7hz
-$ gdbserver 172.17.0.6:7777 --attach 23
-Attached; pid = 23
+```
+We want to attach the `gdbserver` to the node process (`30` in this case but can differ):
+```console
+sh-4.2$ ps -ef
+UID        PID  PPID  C STIME TTY          TIME CMD
+1000120+     1     0  0 03:58 ?        00:00:00 npm
+1000120+    30     1  0 03:58 ?        00:00:00 node .
+1000120+    41     0  0 03:59 ?        00:00:00 /bin/sh
+1000120+    45    41  0 03:59 ?        00:00:00 ps -ef
+$ gdbserver 172.17.0.6:7777 --attach 30
+Attached; pid = 30
 Listening on port 7777
 ```
-In the above case we are creating a new process, but this could also just be the process id of a process running on the pod.
+The gdbserver is now listening for connections.
 
 #### Start the debuginfo image
 The next step is to start a container with the debuginfo image in the same cluster.
 
 ```console
-$ oc run -i -t nodejs-debuginfo --image=bucharestgold/centos7-s2i-nodejs2-debuginfo:10.x --restart=Never
+$ oc run -i -t nodejs-debuginfo --image=bucharestgold/centos7-s2i-nodejs-debuginfo:10.x --restart=Never
 ```
-Then start gdb specifying the executable which is `node` in our case: 
+Running the above command will drop you into the newly created container where 
+the gdb session can be started. This is done using the following command: 
 ```console
 bash-4.2$ gdb node
 Reading symbols from /usr/bin/node...Reading symbols from /usr/lib/debug/usr/bin/node.debug...done.
@@ -33,15 +45,29 @@ Then, start a remote debugging session to the target pod:
 ```console
 (gdb) target remote 172.17.0.6:7777
 ```
-Next breakpoints can be set and debugging can start:
+Next breakpoints can be set and debugging can start. For this example we want to 
+set a breakpoint in [ConnectionWrap::OnConnection](https://github.com/nodejs/node/blob/972d0beb591859a1a0df59a3d1818493a6132bf5/src/connection_wrap.cc#L34) which will be hit when accessing the nodejs-rest-http application:
 ```console
-(gdb) break main
-Breakpoint 1 at 0x95df50: file ../src/node_main.cc, line 94.
-(gdb) continue
-Continuing.
+(gdb) break connection_wrap.cc:36
+Breakpoint 1 at 0x979074: connection_wrap.cc:36. (2 locations)
+```
 
-Breakpoint 1, main (argc=3, argv=0x7fffffffe418) at ../src/node_main.cc:94
-94      int main(int argc, char* argv[]) {
+Next, we need to trigger the breakpoint, which can be done by accessing the endpoint exposed by the application. To find that endpoint url, use the following command:
+```console
+$ oc get route
+NAME               HOST/PORT                                          PATH      SERVICES           PORT      TERMINATION   WILDCARD
+nodejs-rest-http   nodejs-rest-http-myproject.192.168.99.100.nip.io             nodejs-rest-http   8080                    None
+```
+Open `http://nodejs-rest-http-myproject.192.168.99.100.nip.io` in a web browser. This will "hang" as the breakpoint will have been hit and waiting for interaction. Switch back to the console with the debugger and you can inspect variables and step through the code:
+```console
+(gdb) print status
+$2 = 0
+(gdb) print handle
+$3 = (uv_stream_t *) 0x2878268
+```
+To resume normal execution use `continue`:
+```console
+(gdb) continue
 ```
 
 
@@ -52,3 +78,8 @@ The following shows an example of installing debuginfo for `v10.11.0`:
 ```console
 yum install -y https://github.com/bucharest-gold/node-rpm/releases/download/v10.11.0/rhoar-nodejs-debuginfo-10.11.0-1.el7.centos.x86_64.rpm
 ```
+After installing the debuginfo package start gdb and attach to the node process:
+```console
+$ gdb --pid=23
+```
+Breakpoints can now be enabled in the same manner as was shown previously in this document.


### PR DESCRIPTION
This commit adds the building of a second image for debuginfo which is
intended to be used in an OpenShift environment. The image is used to
start a container in the same cluster as a running application and to
be able to remote debug the node application using gdb.

Documentation has been added to a new docs directory as a suggestion and
contains instructions to set this up.