### PR TITLE
src: add httpd24-libcurl to work with git29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ building and running various Node.js $NODEJS_VERSION applications and frameworks
 Node.js is a platform built on Chrome's JavaScript runtime for easily building \
 fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model \
 that makes it lightweight and efficient, perfect for data-intensive real-time applications \
-that run across distributed devices."
+that run across distributed devices." \
+    LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64
 
 LABEL io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Node.js $NODE_VERSION" \

--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-INSTALL_PKGS="centos-release-scl-rh nss_wrapper rh-git29 httpd24-libcurl"
+INSTALL_PKGS="centos-release-scl-rh nss_wrapper rh-git29"
 
 yum remove -y rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon
 

--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-INSTALL_PKGS="centos-release-scl nss_wrapper rh-git29"
+INSTALL_PKGS="centos-release-scl-rh nss_wrapper rh-git29 httpd24-libcurl"
 
 yum remove -y rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon
 
@@ -22,6 +22,7 @@ yum install -y https://github.com/nodeshift/node-rpm/releases/download/v${NODE_V
 
 rpm -V $INSTALL_PKGS
 yum clean all -y
+ldconfig
 
 # Install yarn
 npm install -g yarn -s &>/dev/null

--- a/test/run.sh
+++ b/test/run.sh
@@ -259,6 +259,18 @@ url.https://github.com.insteadof=ssh://git@github.com"
   fi
 }
 
+test_git_clone() {
+  local run_cmd="git clone https://github.com/nodeshift/world && ls world/index.js"
+  local expected="world/index.js"
+
+  echo "Checking git clone ..."
+  out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}")
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+}
+
 test_image_usage_label() {
   local expected="s2i build . nodeshift/centos7-s2i-nodejs myapp"
   echo "Checking image usage label ..."
@@ -315,6 +327,9 @@ test_connection
 check_result $?
 
 test_git_configuration
+check_result $?
+
+test_git_clone
 check_result $?
 
 echo "Testing DEV_MODE=false (default)"


### PR DESCRIPTION
This commit adds the httpd24-libcurl dependency which appears to be
required for git29 but perhaps not installed.

Fixes: https://github.com/nodeshift/centos7-s2i-nodejs/issues/175