### PR TITLE
chore: use npx yarn

### DIFF
--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -24,9 +24,6 @@ rpm -V $INSTALL_PKGS
 yum clean all -y
 ldconfig
 
-# Install yarn
-npm install -g yarn -s &>/dev/null
-
 # Make sure npx is available
 if [ ! -h /usr/bin/npx ] ; then
   ln -s /usr/lib/node_modules/npm/bin/npx-cli.js /usr/bin/npx

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -43,7 +43,7 @@ git config --list
 
 if [ ! -z "$YARN_ENABLED" ]; then
 	echo "---> Using 'yarn install' with YARN_ARGS"
-	yarn install $YARN_ARGS
+	npx yarn install $YARN_ARGS
 else
 	echo "---> Installing dependencies"
 	if [ "$DEV_MODE" == true ]; then


### PR DESCRIPTION
* This removes the yarn install and instead uses npx to call yarn if it is needed

connects to #179 

fixes #179 

This should also be cherry-picked into the 11.x, 10.x and 8.x branches