### PR TITLE
src: removing docker-squash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - sudo chmod 755 /usr/bin/s2i
 
 script:
-  - SKIP_SQUASH=true make all
+  - make all
 
 notifications:
   irc: "chat.freenode.net#bucharest-gold"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ following tools.
 
 * Node.js https://nodejs.org/en/download
 * Docker https://www.docker.com/get-docker
-* docker-squash `pip install docker-squash`
 
 ## Building
 

--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,13 @@ include versions.mk
 TARGET=$(IMAGE_NAME):$(IMAGE_TAG)
 
 .PHONY: all
-all: build squash test
+all: build test
 
 build: Dockerfile s2i contrib
 	docker build \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NPM_VERSION=$(NPM_VERSION) \
 	-t $(TARGET) .
-
-.PHONY: squash
-squash:
-	if [ -z $(SKIP_SQUASH) ] ; then docker-squash -f $(FROM) $(TARGET) -t $(TARGET); fi
-
 
 .PHONY: test
 test: build


### PR DESCRIPTION
The master branch was missing that removal.

Since I installed Fedora29, I get build error because not installed `docker-squash`.

It was done in the past for 8x, 10x and 11x:
https://github.com/nodeshift/centos7-s2i-nodejs/pull/165
https://github.com/nodeshift/centos7-s2i-nodejs/pull/164
https://github.com/nodeshift/centos7-s2i-nodejs/pull/163

