### PR TITLE
fix: add the --pull flag to the build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: Dockerfile s2i contrib
 	docker build \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NPM_VERSION=$(NPM_VERSION) \
-	-t $(TARGET) .
+	--pull -t $(TARGET) .
 
 .PHONY: test
 test: build

--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -3,7 +3,7 @@
 set -ex
 INSTALL_PKGS="centos-release-scl-rh nss_wrapper rh-git218"
 
-yum remove -y rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon
+yum remove -y rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon rh-nodejs8-runtime rh-nodejs10 rh-nodejs10-npm rh-nodejs10-nodejs-nodemon rh-nodejs10-runtime
 
 yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS
 ln -fs /opt/rh/rh-git218/root/usr/bin/git /usr/bin/git


### PR DESCRIPTION
* this will make sure we are always pulling the latest base images


need to cherry-pick this into 8.x and 11.x

i'll send another PR for 10.x