### PR TITLE
add yarn package manager

### DIFF
--- a/contrib/etc/install_node.sh
+++ b/contrib/etc/install_node.sh
@@ -29,6 +29,9 @@ if [ ! -h /usr/bin/npx ] ; then
   ln -s /usr/lib/node_modules/npm/bin/npx-cli.js /usr/bin/npx
 fi
 
+# Install YARN package manager
+npm install --global yarn
+
 echo "---> Setting directory write permissions"
 fix-permissions /opt/app-root
 


### PR DESCRIPTION
The assemble script already has support for yarn, but the actual yarn binary itself isn't installed 